### PR TITLE
Add hot fix to thunk function.

### DIFF
--- a/Controllers/feedbackController.js
+++ b/Controllers/feedbackController.js
@@ -216,7 +216,7 @@ const addFeedBack = async (req, res) => {
       msg: "Feedback added successfully",
       data: createdFeedback,
     });
-    mentorNotification(feedBackData);
+    // mentorNotification(feedBackData);
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: "An error occurred adding feedback" });
@@ -303,9 +303,9 @@ const getAssignedFeedBacks = async (req, res) => {
     let assignedList = await FeedbackRequest.findAll({
       where: {
         whoisAssigned: fullName.fName,
-        // status: {
-        //   [Op.not]: true,
-        // },
+        status: {
+          [Op.not]: true,
+        },
       },
     });
     res.status(200).json({ data: assignedList });

--- a/Controllers/feedbackController.js
+++ b/Controllers/feedbackController.js
@@ -283,6 +283,10 @@ const getAssignedFeedBacks = async (req, res) => {
     const { authToken } = req.cookies;
     const { id, username } = jwt.verify(authToken, process.env.JWT_SECRET);
 
+    let fullName = await User.findOne({
+      where: { id: id },
+    });
+
     // Check if the user is a mentor
     const isMentor = await User.findOne({
       where: {
@@ -298,13 +302,12 @@ const getAssignedFeedBacks = async (req, res) => {
 
     let assignedList = await FeedbackRequest.findAll({
       where: {
-        whoisAssigned: username,
-        status: {
-          [Op.not]: true,
-        },
+        whoisAssigned: fullName.fName,
+        // status: {
+        //   [Op.not]: true,
+        // },
       },
     });
-    console.log(assignedList);
     res.status(200).json({ data: assignedList });
   } catch (err) {
     console.error(err);

--- a/views/src/Pages/AssignedFeedback.jsx
+++ b/views/src/Pages/AssignedFeedback.jsx
@@ -23,6 +23,7 @@ function AssignedFeedback() {
       {assignedFeedbacks && (
         <FeedbackCard
           data={assignedFeedbacks}
+          isMentor={true}
           showAddFeedback={true}
           showComplete={true}
           pageTitle="MY ASSIGNED FEEDBACKS"

--- a/views/src/Pages/CreatedRequests.jsx
+++ b/views/src/Pages/CreatedRequests.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import FeedbackCard from "../components/FeedbackCard";
 import { useDispatch, useSelector } from "react-redux";
-import { fetchFeedbackRequests } from "../features/Feedbacks/feedbackSlice";
+import { fetchInternFeedbackRequests } from "../features/Feedbacks/feedbackSlice";
 
 function CreatedRequests() {
 
@@ -11,7 +11,7 @@ function CreatedRequests() {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(fetchFeedbackRequests());
+    dispatch(fetchInternFeedbackRequests());
   }, [dispatch]);
 
   return (

--- a/views/src/components/FeedbackCard.jsx
+++ b/views/src/components/FeedbackCard.jsx
@@ -99,7 +99,7 @@ function FeedbackCard({
                 {isMentor ? (
                   <Text>Intern Name: {item.studentName}</Text>
                 ) : (
-                  <Text>Reviewer Name: {item.whoisAssigned}</Text>
+                  <Text>{item.whoisAssigned? "Reviewer Name:" : "Reviewer Name: Not Assigned"} {item.whoisAssigned}</Text>
                 )}
                 <Text>
                   Topic Of Learning Session: {item.topicOfLearningSession}

--- a/views/src/components/FeedbackCard.jsx
+++ b/views/src/components/FeedbackCard.jsx
@@ -97,9 +97,9 @@ function FeedbackCard({
             >
               <div>
                 {isMentor ? (
-                  <Text>Code Lead: {item.CodeLead}</Text>
-                ) : (
                   <Text>Intern Name: {item.studentName}</Text>
+                ) : (
+                  <Text>Reviewer Name: {item.whoisAssigned}</Text>
                 )}
                 <Text>
                   Topic Of Learning Session: {item.topicOfLearningSession}

--- a/views/src/features/Feedbacks/feedbackSlice.js
+++ b/views/src/features/Feedbacks/feedbackSlice.js
@@ -9,14 +9,28 @@ const initialState = {
   error: null,
 };
 
-const createAsyncThunkWithJwt = (type, url, method = "get") => createAsyncThunk(type, async ( data, thunkAPI) => {
+const createAsyncThunkWithJwt = (type, url, method = "get") => createAsyncThunk(type, async (data, thunkAPI) => {
   try {
+    let apiUrl = url;
+
+    if (typeof data ==='number'){
+      apiUrl =  `${url}${data}`
+    }
+
+    if (typeof data === 'object' && data.id) {
+      apiUrl = `${url}${data.id}`;
+    }
+
+
+    console.log(apiUrl);
+
     const response = await axios({
       method,
-      url: data?.id ? `${url}${data.id}` : url,
-      data,
+      url: apiUrl,
+      data: typeof data === 'object' ? data : undefined,
       withCredentials: true,
     });
+
     return response.data;
   } catch (error) {
     return thunkAPI.rejectWithValue(error.response.data);
@@ -25,11 +39,18 @@ const createAsyncThunkWithJwt = (type, url, method = "get") => createAsyncThunk(
 
 
 const createFeedbackRequest = createAsyncThunkWithJwt("feedback/create", "http://localhost:5001/api/feedback/submitfeedback", "post");
+
 const addFeedback = createAsyncThunkWithJwt("feedback/add", "http://localhost:5001/api/feedback/add", "post");
+
 const assignFeedbackRequest = createAsyncThunkWithJwt("feedback/assign", "http://localhost:5001/api/feedback/assignFeedBackToMentor/", "post");
+
 const getAssignedFeedbackRequests = createAsyncThunkWithJwt("feedback/getAssign", "http://localhost:5001/api/feedback/getAssignedFeedBacks");
 const fetchFeedbackRequests = createAsyncThunkWithJwt("feedback/fetchAll", "http://localhost:5001/api/feedback/getfeedbackrequestForms");
+
+const fetchInternFeedbackRequests = createAsyncThunkWithJwt("feedback/fetchAll", "http://localhost:5001/api/feedback/getUserFeedBackRequestForms");
+
 const getSelectedFeedbackRequest = createAsyncThunk('feedback/getSelectedRequest', "http://localhost:5001/api/feedback/getfeedbackid/"); 
+
 const markComplete = createAsyncThunkWithJwt("feedback/markComplete", "http://localhost:5001/api/feedback/markFeedBackRequestComplete/", "get");
 
 const feedbackSlice = createSlice({
@@ -96,6 +117,7 @@ export {
   assignFeedbackRequest,
   getAssignedFeedbackRequests,
   getSelectedFeedbackRequest,
+  fetchInternFeedbackRequests,
   markComplete,
 };
 


### PR DESCRIPTION
Context: Due to the way the thunk function was setup, it was difficult to make the right post api calls
if the response was an object or just a plain id. 

- Refactored function to account for used data types. 

- Commented out the flock notification that send out a notification feedback addition
  ( Since only code leads will be in the notification channel, there's no need for that.  replacing that with an email notification instead as part of a later code improvement plan).
  
 - Fixed the controller responsible for retrieving all the feedback requests code leads have assigned to 
   themselves. Since a previous code change introduced the use of full names instead of just the usernames.
   
 - Added a value for the `isMentor` prop in the `AssignedFeedback` page so that the correct titles are displayed in the feedback card. 
 
 - Added a small UI update to the verbiage when a code lead is not assigned to the feed back request