### PR TITLE
Fix redis concurrency and invalidation

### DIFF
--- a/Controllers/feedbackController.js
+++ b/Controllers/feedbackController.js
@@ -177,7 +177,7 @@ const getMentorFeedback = async (req, res) => {
   } catch (err) {
     res.status(500).json({ error: "Internal server error" });
     logger.error(`Feedback was not fetched due to error`, {
-      error: JSON.stringify(error),
+      error: JSON.stringify(err),
     });
   }
 };

--- a/Controllers/feedbackController.js
+++ b/Controllers/feedbackController.js
@@ -21,7 +21,7 @@ feedback forms.
  */
 
 const submitFeedBack = async (req, res) => {
-  const [id, username] = getToken(req);
+  const { id } = getToken(req);
   const { topicOfLearningSession, codeLink } = req.body;
   const { errors, validationCheck } = feedbackrequestValidator(req.body);
 
@@ -83,7 +83,7 @@ const submitFeedBack = async (req, res) => {
  */
 const getAllFeedBackRequestsForms = async (req, res) => {
   try {
-    const [id, username] = getToken.getToken(req);
+    const { id } = getToken.getToken(req);
     const redisResponse = await redisFunctions.cacheGetFeedbackRequestForms(id);
     if (redisResponse !== "No Cache Hit") {
       logger.info("Success: Feedback Request Forms Retrieved from Cache");
@@ -119,7 +119,7 @@ const getAllFeedBackRequestsForms = async (req, res) => {
 that is logged in */
 const getUserFeedBackRequestForms = async (req, res) => {
   try {
-    const [id, username] = getToken.getToken(req);
+    const { id } = getToken.getToken(req);
     const redisResponse = await redisFunctions.cacheGetUserFeedbackRequestForms(
       id
     );
@@ -187,7 +187,7 @@ This controller is used to trigger the flock webhook that is
 used to notify the code leads that an intern needs a code review.
 */
 const flockNotification = async (req, res) => {
-  const [id, username] = getToken(req);
+  const { id } = getToken(req);
   const { topicOfLearningSession, codeLink } = req.body;
 
   try {
@@ -218,7 +218,7 @@ for
 const assignFeedBack = async (req, res) => {
   try {
     const { feedbackrequestId } = req.params;
-    const [id, username] = getToken.getToken(req);
+    const { id, username } = getToken.getToken(req);
     // Grab the user information based on the id for updates of the request form.
     const userDetail = await User.findOne({
       where: username,
@@ -262,7 +262,7 @@ const addFeedBack = async (req, res) => {
     const { feedback } = req.body;
     const { errors, validationCheck } = feedbackValidator(req.body);
     const { feedbackrequestId } = req.params;
-    const [id, username] = getToken(req);
+    const { id } = getToken(req);
 
     if (!validationCheck) {
       logger.error(`Bad Input:`, { log: JSON.stringify(errors) });
@@ -321,7 +321,7 @@ of the user logged in.
  */
 const getAssignedFeedBacks = async (req, res) => {
   try {
-    const [id, username] = getToken.getToken(req);
+    const { id } = getToken.getToken(req);
     const redisResponse = await redisFunctions.cacheGetAssignedFeedbacks(id);
     if (redisResponse !== "No Cache Hit") {
       logger.info("Success: Assigned Feedbacks Retrieved from Cache");
@@ -395,7 +395,7 @@ const getSelectedFeedback = async (req, res) => {
 const markFeedbackRequestComplete = async (req, res) => {
   try {
     const { feedbackrequestId } = req.params;
-    const [id, username] = getToken(req);
+    const { id } = getToken(req);
 
     let markAsComplete = await FeedbackRequest.findOne({
       where: { id: feedbackrequestId },

--- a/Controllers/feedbackController.js
+++ b/Controllers/feedbackController.js
@@ -21,7 +21,7 @@ feedback forms.
  */
 
 const submitFeedBack = async (req, res) => {
-  const id = getToken(req);
+  const [id, username] = getToken(req);
   const { topicOfLearningSession, codeLink } = req.body;
   const { errors, validationCheck } = feedbackrequestValidator(req.body);
 
@@ -83,10 +83,8 @@ const submitFeedBack = async (req, res) => {
  */
 const getAllFeedBackRequestsForms = async (req, res) => {
   try {
-    const token = getToken.getToken(req);
-    const redisResponse = await redisFunctions.cacheGetFeedbackRequestForms(
-      token
-    );
+    const [id, username] = getToken.getToken(req);
+    const redisResponse = await redisFunctions.cacheGetFeedbackRequestForms(id);
     if (redisResponse !== "No Cache Hit") {
       logger.info("Success: Feedback Request Forms Retrieved from Cache");
       return res.status(200).json({ data: redisResponse });
@@ -106,7 +104,7 @@ const getAllFeedBackRequestsForms = async (req, res) => {
         "FeedbackRequestForms",
         1000,
         redisEntry,
-        token
+        id
       );
       logger.info("Success: Feedback Request Forms Cached");
       return res.status(200).json({ data: feedBackrequests });
@@ -121,9 +119,9 @@ const getAllFeedBackRequestsForms = async (req, res) => {
 that is logged in */
 const getUserFeedBackRequestForms = async (req, res) => {
   try {
-    const token = getToken.getToken(req);
+    const [id, username] = getToken.getToken(req);
     const redisResponse = await redisFunctions.cacheGetUserFeedbackRequestForms(
-      token
+      id
     );
     if (redisResponse !== "No Cache Hit") {
       logger.info("Success: User Feedback Request Forms Retrieved from Cache");
@@ -132,7 +130,6 @@ const getUserFeedBackRequestForms = async (req, res) => {
       logger.info(
         "User Feedback Request Forms not Found In Cache: Fetching From Database"
       );
-      const id = getToken.getToken(req);
       let singleFeedBack = await FeedbackRequest.findAll({
         where: { userId: id },
       });
@@ -141,7 +138,7 @@ const getUserFeedBackRequestForms = async (req, res) => {
         "UserFeedbackRequestForms",
         1000,
         redisEntry,
-        token
+        id
       );
       logger.info("Success: User Feedback Request Forms Cached");
       res.status(200).json({ data: singleFeedBack });
@@ -190,7 +187,7 @@ This controller is used to trigger the flock webhook that is
 used to notify the code leads that an intern needs a code review.
 */
 const flockNotification = async (req, res) => {
-  const id = getToken(req);
+  const [id, username] = getToken(req);
   const { topicOfLearningSession, codeLink } = req.body;
 
   try {
@@ -221,8 +218,7 @@ for
 const assignFeedBack = async (req, res) => {
   try {
     const { feedbackrequestId } = req.params;
-    const id = getToken.getToken(req);
-
+    const [id, username] = getToken.getToken(req);
     // Grab the user information based on the id for updates of the request form.
     const userDetail = await User.findOne({
       where: username,
@@ -266,7 +262,7 @@ const addFeedBack = async (req, res) => {
     const { feedback } = req.body;
     const { errors, validationCheck } = feedbackValidator(req.body);
     const { feedbackrequestId } = req.params;
-    const id = getToken(req);
+    const [id, username] = getToken(req);
 
     if (!validationCheck) {
       logger.error(`Bad Input:`, { log: JSON.stringify(errors) });
@@ -325,7 +321,7 @@ of the user logged in.
  */
 const getAssignedFeedBacks = async (req, res) => {
   try {
-    const id = getToken.getToken(req);
+    const [id, username] = getToken.getToken(req);
     const redisResponse = await redisFunctions.cacheGetAssignedFeedbacks(id);
     if (redisResponse !== "No Cache Hit") {
       logger.info("Success: Assigned Feedbacks Retrieved from Cache");
@@ -399,7 +395,7 @@ const getSelectedFeedback = async (req, res) => {
 const markFeedbackRequestComplete = async (req, res) => {
   try {
     const { feedbackrequestId } = req.params;
-    const id = getToken(req);
+    const [id, username] = getToken(req);
 
     let markAsComplete = await FeedbackRequest.findOne({
       where: { id: feedbackrequestId },

--- a/Controllers/feedbackController.js
+++ b/Controllers/feedbackController.js
@@ -83,7 +83,7 @@ const submitFeedBack = async (req, res) => {
  */
 const getAllFeedBackRequestsForms = async (req, res) => {
   try {
-    const { id } = getToken.getToken(req);
+    const { id } = getToken(req);
     const redisResponse = await redisFunctions.cacheGetFeedbackRequestForms(id);
     if (redisResponse !== "No Cache Hit") {
       logger.info("Success: Feedback Request Forms Retrieved from Cache");
@@ -119,7 +119,7 @@ const getAllFeedBackRequestsForms = async (req, res) => {
 that is logged in */
 const getUserFeedBackRequestForms = async (req, res) => {
   try {
-    const { id } = getToken.getToken(req);
+    const { id } = getToken(req);
     const redisResponse = await redisFunctions.cacheGetUserFeedbackRequestForms(
       id
     );
@@ -218,7 +218,7 @@ for
 const assignFeedBack = async (req, res) => {
   try {
     const { feedbackrequestId } = req.params;
-    const { id, username } = getToken.getToken(req);
+    const { id, username } = getToken(req);
     // Grab the user information based on the id for updates of the request form.
     const userDetail = await User.findOne({
       where: username,
@@ -321,7 +321,7 @@ of the user logged in.
  */
 const getAssignedFeedBacks = async (req, res) => {
   try {
-    const { id } = getToken.getToken(req);
+    const { id } = getToken(req);
     const redisResponse = await redisFunctions.cacheGetAssignedFeedbacks(id);
     if (redisResponse !== "No Cache Hit") {
       logger.info("Success: Assigned Feedbacks Retrieved from Cache");

--- a/Controllers/feedbackController.js
+++ b/Controllers/feedbackController.js
@@ -83,7 +83,10 @@ const submitFeedBack = async (req, res) => {
  */
 const getAllFeedBackRequestsForms = async (req, res) => {
   try {
-    const redisResponse = await redisFunctions.cacheGetFeedbackRequestForms();
+    const token = redisFunctions.getToken();
+    const redisResponse = await redisFunctions.cacheGetFeedbackRequestForms(
+      token
+    );
     if (redisResponse !== "No Cache Hit") {
       logger.info("Success: Feedback Request Forms Retrieved from Cache");
       return res.status(200).json({ data: redisResponse });
@@ -99,7 +102,12 @@ const getAllFeedBackRequestsForms = async (req, res) => {
         },
       });
       const redisEntry = JSON.stringify(feedBackrequests);
-      await redisFunctions.redisSetEX("FeedbackRequestForms", 1000, redisEntry);
+      await redisFunctions.redisSetEX(
+        "FeedbackRequestForms",
+        1000,
+        redisEntry,
+        token
+      );
       logger.info("Success: Feedback Request Forms Cached");
       return res.status(200).json({ data: feedBackrequests });
     }
@@ -113,6 +121,7 @@ const getAllFeedBackRequestsForms = async (req, res) => {
 that is logged in */
 const getUserFeedBackRequestForms = async (req, res) => {
   try {
+    const token = redisFunctions.getToken();
     const redisResponse =
       await redisFunctions.cacheGetUserFeedbackRequestForms();
     if (redisResponse !== "No Cache Hit") {
@@ -131,7 +140,8 @@ const getUserFeedBackRequestForms = async (req, res) => {
       await redisFunctions.redisSetEX(
         "UserFeedbackRequestForms",
         1000,
-        redisEntry
+        redisEntry,
+        token
       );
       logger.info("Success: User Feedback Request Forms Cached");
       res.status(200).json({ data: singleFeedBack });
@@ -318,7 +328,8 @@ of the user logged in.
  */
 const getAssignedFeedBacks = async (req, res) => {
   try {
-    const redisResponse = await redisFunctions.cacheGetAssignedFeedbacks();
+    const token = redisFunctions.getToken();
+    const redisResponse = await redisFunctions.cacheGetAssignedFeedbacks(token);
     if (redisResponse !== "No Cache Hit") {
       logger.info("Success: Assigned Feedbacks Retrieved from Cache");
       return res.status(200).json({ data: redisResponse });
@@ -342,7 +353,12 @@ const getAssignedFeedBacks = async (req, res) => {
         },
       });
       const redisEntry = JSON.stringify(assignedList);
-      await redisFunctions.redisSetEX("AssignedFeedbacks", 1000, redisEntry);
+      await redisFunctions.redisSetEX(
+        "AssignedFeedbacks",
+        1000,
+        redisEntry,
+        token
+      );
       logger.info(`List fetched successfully`, {
         log: JSON.stringify(assignedList),
       });

--- a/Controllers/userController.js
+++ b/Controllers/userController.js
@@ -172,8 +172,8 @@ const logout = async (req, res) => {
 // the app know whether or not a user is logged in.
 const authorized = async (req, res) => {
   try {
-    let { id } = getToken(req);
-    let userInfo = await redisFunctions.cacheGetUserInfo(id);
+    let { id: token } = getToken(req);
+    let userInfo = await redisFunctions.cacheGetUserInfo(token);
     if (!userInfo) {
       logger.info("Auth not found in cache");
       let {

--- a/Controllers/userController.js
+++ b/Controllers/userController.js
@@ -150,7 +150,7 @@ const loginUser = async (req, res) => {
 //This logs the user out the app by removing the
 //Users token
 const logout = async (req, res) => {
-  const [id, username] = getToken.getToken(req);
+  const { id } = getToken.getToken(req);
   await res.clearCookie("authToken", {
     httpOnly: true,
     secure: true,

--- a/Controllers/userController.js
+++ b/Controllers/userController.js
@@ -197,7 +197,15 @@ const authorized = async (req, res) => {
           updatedAt: updatedAt,
         })
       );
-      return res.json({ user: res.locals.user });
+      return res.json({
+        user: {
+          id: id,
+          fName: fName,
+          username: username,
+          createdAt: createdAt,
+          updatedAt: updatedAt,
+        },
+      });
     } else {
       logger.info("Auth done from cache");
       return res.json({ user: JSON.parse(userInfo) });

--- a/Controllers/userController.js
+++ b/Controllers/userController.js
@@ -172,12 +172,12 @@ const logout = async (req, res) => {
 // the app know whether or not a user is logged in.
 const authorized = async (req, res) => {
   try {
-    const { token } = getToken(req);
-    let userInfo = await redisFunctions.cacheGetUserInfo(token);
+    let { id } = getToken(req);
+    let userInfo = await redisFunctions.cacheGetUserInfo(id);
     if (!userInfo) {
       logger.info("Auth not found in cache");
       let {
-        id,
+        userId,
         fName,
         username,
         password,
@@ -190,7 +190,7 @@ const authorized = async (req, res) => {
         `UserInfo-${token}`,
         1000,
         JSON.stringify({
-          id: id,
+          id: userId,
           fName: fName,
           username: username,
           createdAt: createdAt,
@@ -199,7 +199,7 @@ const authorized = async (req, res) => {
       );
       return res.json({
         user: {
-          id: id,
+          id: userIdd,
           fName: fName,
           username: username,
           createdAt: createdAt,

--- a/Controllers/userController.js
+++ b/Controllers/userController.js
@@ -177,7 +177,7 @@ const authorized = async (req, res) => {
     if (!userInfo) {
       logger.info("Auth not found in cache");
       let {
-        userId,
+        id,
         fName,
         username,
         password,
@@ -190,7 +190,7 @@ const authorized = async (req, res) => {
         `UserInfo-${token}`,
         1000,
         JSON.stringify({
-          id: userId,
+          id: id,
           fName: fName,
           username: username,
           createdAt: createdAt,
@@ -199,7 +199,7 @@ const authorized = async (req, res) => {
       );
       return res.json({
         user: {
-          id: userIdd,
+          id: id,
           fName: fName,
           username: username,
           createdAt: createdAt,

--- a/Controllers/userController.js
+++ b/Controllers/userController.js
@@ -176,9 +176,26 @@ const authorized = async (req, res) => {
     let userInfo = await redisFunctions.cacheGetUserInfo(token);
     if (!userInfo) {
       logger.info("Auth not found in cache");
-      await redisClient.SET(
+      let {
+        id,
+        fName,
+        username,
+        password,
+        mentor,
+        mentorId,
+        createdAt,
+        updatedAt,
+      } = res.locals.user;
+      await redisClient.SETEX(
         `UserInfo-${token}`,
-        JSON.stringify(res.locals.user)
+        1000,
+        JSON.stringify({
+          id: id,
+          fName: fName,
+          username: username,
+          createdAt: createdAt,
+          updatedAt: updatedAt,
+        })
       );
       return res.json({ user: res.locals.user });
     } else {

--- a/Controllers/userController.js
+++ b/Controllers/userController.js
@@ -150,7 +150,7 @@ const loginUser = async (req, res) => {
 //This logs the user out the app by removing the
 //Users token
 const logout = async (req, res) => {
-  const token = getToken.getToken(req);
+  const [id, username] = getToken.getToken(req);
   await res.clearCookie("authToken", {
     httpOnly: true,
     secure: true,
@@ -158,10 +158,10 @@ const logout = async (req, res) => {
     path: "/",
   });
   await redisFunctions.cacheInvalidator([
-    `FeedbackRequestForms-${token}`,
-    `UserFeedbackRequestForms-${token}`,
-    `AssignedFeedbacks-${token}`,
-    `UserInfo-${token}`,
+    `FeedbackRequestForms-${id}`,
+    `UserFeedbackRequestForms-${id}`,
+    `AssignedFeedbacks-${id}`,
+    `UserInfo-${id}`,
   ]);
   await redisClient.quit();
   res.status(200).json({ msg: "User was Logged Out Successfully" });
@@ -172,7 +172,7 @@ const logout = async (req, res) => {
 // the app know whether or not a user is logged in.
 const authorized = async (req, res) => {
   try {
-    const token = getToken.getToken(req);
+    const [token, uName] = getToken.getToken(req);
     let userInfo = await redisFunctions.cacheGetUserInfo(token);
     if (!userInfo) {
       logger.info("Auth not found in cache");
@@ -217,7 +217,7 @@ const authorized = async (req, res) => {
 
 // This lets us update a users account information everywhere
 const updateAccount = async (req, res) => {
-  const id = getToken(req);
+  const [id, uName] = getToken(req);
   const { fName, username, oldPassword, newPassword } = req.body;
   const isUserExist = await Users.findOne({ where: { id: id } });
 

--- a/Controllers/userController.js
+++ b/Controllers/userController.js
@@ -150,7 +150,7 @@ const loginUser = async (req, res) => {
 //This logs the user out the app by removing the
 //Users token
 const logout = async (req, res) => {
-  const { id } = getToken.getToken(req);
+  const { id } = getToken(req);
   await res.clearCookie("authToken", {
     httpOnly: true,
     secure: true,
@@ -172,7 +172,7 @@ const logout = async (req, res) => {
 // the app know whether or not a user is logged in.
 const authorized = async (req, res) => {
   try {
-    const [token, uName] = getToken.getToken(req);
+    const { token } = getToken(req);
     let userInfo = await redisFunctions.cacheGetUserInfo(token);
     if (!userInfo) {
       logger.info("Auth not found in cache");
@@ -217,7 +217,7 @@ const authorized = async (req, res) => {
 
 // This lets us update a users account information everywhere
 const updateAccount = async (req, res) => {
-  const [id, uName] = getToken(req);
+  const { id } = getToken(req);
   const { fName, username, oldPassword, newPassword } = req.body;
   const isUserExist = await Users.findOne({ where: { id: id } });
 

--- a/Controllers/userController.js
+++ b/Controllers/userController.js
@@ -180,9 +180,6 @@ const authorized = async (req, res) => {
         id,
         fName,
         username,
-        password,
-        mentor,
-        mentorId,
         createdAt,
         updatedAt,
       } = res.locals.user;

--- a/Controllers/userController.js
+++ b/Controllers/userController.js
@@ -176,13 +176,7 @@ const authorized = async (req, res) => {
     let userInfo = await redisFunctions.cacheGetUserInfo(token);
     if (!userInfo) {
       logger.info("Auth not found in cache");
-      let {
-        id,
-        fName,
-        username,
-        createdAt,
-        updatedAt,
-      } = res.locals.user;
+      let { id, fName, username, createdAt, updatedAt } = res.locals.user;
       await redisClient.SETEX(
         `UserInfo-${token}`,
         1000,

--- a/utility/getToken/getToken.js
+++ b/utility/getToken/getToken.js
@@ -1,8 +1,8 @@
 const jwt = require("jsonwebtoken");
 const getToken = (req) => {
   const { authToken } = req.cookies;
-  const { id } = jwt.verify(authToken, process.env.JWT_SECRET);
-  return id;
+  const { id, username } = jwt.verify(authToken, process.env.JWT_SECRET);
+  return [id, username];
 };
 module.exports = {
   getToken,

--- a/utility/getToken/getToken.js
+++ b/utility/getToken/getToken.js
@@ -2,7 +2,7 @@ const jwt = require("jsonwebtoken");
 const getToken = (req) => {
   const { authToken } = req.cookies;
   const { id, username } = jwt.verify(authToken, process.env.JWT_SECRET);
-  return [id, username];
+  return { id: id, username: username };
 };
 module.exports = {
   getToken,

--- a/utility/getToken/getToken.js
+++ b/utility/getToken/getToken.js
@@ -1,9 +1,6 @@
 const jwt = require("jsonwebtoken");
-const getToken = (req) => {
+module.exports = (req) => {
   const { authToken } = req.cookies;
   const { id, username } = jwt.verify(authToken, process.env.JWT_SECRET);
   return { id: id, username: username };
-};
-module.exports = {
-  getToken,
 };

--- a/utility/getToken/getToken.js
+++ b/utility/getToken/getToken.js
@@ -1,0 +1,9 @@
+const jwt = require("jsonwebtoken");
+const getToken = (req) => {
+  const { authToken } = req.cookies;
+  const { id } = jwt.verify(authToken, process.env.JWT_SECRET);
+  return id;
+};
+module.exports = {
+  getToken,
+};

--- a/utility/redisCaching/redisFunctions.js
+++ b/utility/redisCaching/redisFunctions.js
@@ -1,5 +1,6 @@
 const redisClient = require("../redisCaching/redisCache");
 const logger = require("../logger/logger");
+require("dotenv").config();
 
 const redisGet = async (key) => {
   try {
@@ -91,9 +92,7 @@ const cacheGetUserInfo = async (token) => {
     logger.error(err);
   }
 };
-const getToken = async (req, res) => {
-  return;
-};
+
 module.exports = {
   redisGet,
   redisSetEX,
@@ -102,6 +101,5 @@ module.exports = {
   cacheGetUserFeedbackRequestForms,
   cacheGetAssignedFeedbacks,
   cacheInvalidator,
-  getToken,
   cacheGetUserInfo,
 };

--- a/utility/redisCaching/redisFunctions.js
+++ b/utility/redisCaching/redisFunctions.js
@@ -1,7 +1,6 @@
 const redisClient = require("../redisCaching/redisCache");
 const logger = require("../logger/logger");
 
-
 const redisGet = async (key) => {
   try {
     const response = await redisClient.GET(key);
@@ -11,9 +10,9 @@ const redisGet = async (key) => {
   }
 };
 
-const redisSetEX = async (key, seconds, value) => {
+const redisSetEX = async (key, seconds, value, token) => {
   try {
-    await redisClient.SETEX(key, seconds, value);
+    await redisClient.SETEX(`${key}-${token}`, seconds, value);
   } catch (err) {
     console.error(err);
   }
@@ -21,7 +20,7 @@ const redisSetEX = async (key, seconds, value) => {
 
 const cacheGetAllExerciseInfo = async () => {
   try {
-    let cacheResponse = await redisGet("ExerciseInfo");
+    let cacheResponse = await redisGet(`ExerciseInfo`);
     if (cacheResponse) {
       let response = JSON.parse(cacheResponse);
       return response;
@@ -33,9 +32,9 @@ const cacheGetAllExerciseInfo = async () => {
   }
 };
 
-const cacheGetFeedbackRequestForms = async () => {
+const cacheGetFeedbackRequestForms = async (token) => {
   try {
-    let cacheResponse = await redisGet("FeedbackRequestForms");
+    let cacheResponse = await redisGet(`FeedbackRequestForms-${token}`);
     if (cacheResponse) {
       let response = JSON.parse(cacheResponse);
       return response;
@@ -47,9 +46,9 @@ const cacheGetFeedbackRequestForms = async () => {
   }
 };
 
-const cacheGetUserFeedbackRequestForms = async () => {
+const cacheGetUserFeedbackRequestForms = async (token) => {
   try {
-    let cacheResponse = await redisGet("UserFeedbackRequestForms");
+    let cacheResponse = await redisGet(`UserFeedbackRequestForms-${token}`);
     if (cacheResponse) {
       let response = JSON.parse(cacheResponse);
       return response;
@@ -61,9 +60,9 @@ const cacheGetUserFeedbackRequestForms = async () => {
   }
 };
 
-const cacheGetAssignedFeedbacks = async () => {
+const cacheGetAssignedFeedbacks = async (token) => {
   try {
-    let cacheResponse = await redisGet("AssignedFeedbacks");
+    let cacheResponse = await redisGet(`AssignedFeedbacks-${token}`);
     if (cacheResponse) {
       let response = JSON.parse(cacheResponse);
       return response;
@@ -84,7 +83,17 @@ const cacheInvalidator = async (keys) => {
     logger.error(error);
   }
 };
-
+const cacheGetUserInfo = async (token) => {
+  try {
+    const response = await redisGet(`UserInfo-${token}`);
+    return JSON.parse(response);
+  } catch (err) {
+    logger.error(err);
+  }
+};
+const getToken = async (req, res) => {
+  return;
+};
 module.exports = {
   redisGet,
   redisSetEX,
@@ -93,4 +102,6 @@ module.exports = {
   cacheGetUserFeedbackRequestForms,
   cacheGetAssignedFeedbacks,
   cacheInvalidator,
+  getToken,
+  cacheGetUserInfo,
 };


### PR DESCRIPTION
Implemented the following:

1. getToken utility function to modularise fetching of id from session-specific cookies
2. Complete invalidation of user-specific cache items when a user logs out
3. Updated redis key naming syntax to "key-id" instead of "key" for user-specific info
4. Added invalidation support for the new syntax when the db is updated
5. Removed some redundant mentor code
6. Avoids concurrenct user issues and cache backup